### PR TITLE
fix layout of prepended elements

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -141,7 +141,9 @@ var MasonryComponent = React.createClass({
 
         if (diff.appended.length > 0) {
             this.masonry.appended(diff.appended);
-            this.masonry.reloadItems();
+            if (diff.prepended.length === 0) {
+                this.masonry.reloadItems();
+            }
         }
 
         if (diff.prepended.length > 0) {


### PR DESCRIPTION
**The  issue**
We are using the Masonry to render a grid with flexible column width. The issue encountered is similar to described in #11. Tiles appear to be stacked after filtering operations.

**The change**:
 Don't perform reloadItems after append if there are items to prepend.
 _More_ details:
Currently in case that we have items that some are categorised to be appended and the other are prepended then MasonryComponnet would append the items and immediately perform reloadItems, after it will attempt to prepend. This resulted with wrong prepended elements layout.
The change was to perform reloadItems after append only if no prepeneded items found.

_Explanation_
as a result of `masonry.reloadItems` invocation `this.items` in outlayer.js will already contain the items that should only now be prepended. As you can see in the code of prepend function below they will be used in layout of new items and as previous items at the same time.

``` javascript
proto.prepended = function( elems ) {
  var items = this._itemize( elems );
  if ( !items.length ) {
    return;
  }
  // add items to beginning of collection
  var previousItems = this.items.slice(0); // at this point this.items already contain the prepended element and thus will be contained in the previous items list as well.
  this.items = items.concat( previousItems );
  // start new layout
  this._resetLayout();
  this._manageStamps();
  // layout new stuff without transition
  this.layoutItems( items, true );
  this.reveal( items );
  // layout previous items
  this.layoutItems( previousItems );
};
```
