### PR TITLE
cleanup masonry when unmounted to prevent memory leak

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -187,6 +187,7 @@ var MasonryComponent = React.createClass({
 
     componentWillUnmount: function() {
         clearTimeout(this._timer);
+        this.masonry.destroy();
     },
 
     render: function() {


### PR DESCRIPTION
GC seems to be unable to free masonry item nodes, if destroy() is not called when React component is unmounted, resulting in a memory leak. 