### PR TITLE
add updateOnEachImageLoad prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ var Gallery = React.createClass({
                 elementType={'ul'} // default 'div'
                 options={masonryOptions} // default {}
                 disableImagesLoaded={false} // default false
-                updateOnEachImageLoad={false} // default false and works only if disableImagesLoaded is true
+                updateOnEachImageLoad={false} // default false and works only if disableImagesLoaded is false
             >
                 {childElements}
             </Masonry>

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ var Gallery = React.createClass({
                 elementType={'ul'} // default 'div'
                 options={masonryOptions} // default {}
                 disableImagesLoaded={false} // default false
+                updateOnEachImageLoad={false} // default false and works only if disableImagesLoaded is true
             >
                 {childElements}
             </Masonry>

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,6 +15,20 @@ function extend() {
     return result;
 }
 
+function debounce (func, wait, immediate) {
+    var timeout;
+    return function() {
+        var context = this, args = arguments;
+        var later = function() {
+            timeout = null;
+            if (!immediate) func.apply(context, args);
+        };
+        var callNow = immediate && !timeout;
+        clearTimeout(timeout);
+        timeout = setTimeout(later, wait);
+        if (callNow) func.apply(context, args);
+    };
+}
 
 var MasonryComponent = React.createClass({
     masonry: false,
@@ -163,9 +177,9 @@ var MasonryComponent = React.createClass({
         imagesloaded(this.refs[refName])
         .on(
             this.props.updateOnEachImageLoad? 'progress' : 'always',
-            function(instance) {
-              this.masonry.layout();
-            }.bind(this)
+            debounce(function(instance){
+                this.masonry.layout();
+            }.bind(this), 100)
         );
     },
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -160,10 +160,11 @@ var MasonryComponent = React.createClass({
     imagesLoaded: function() {
         if (this.props.disableImagesLoaded) return;
 
-        imagesloaded(
-            this.refs[refName],
+        imagesloaded(this.refs[refName])
+        .on(
+            this.props.updateOnEachImageLoad? 'progress' : 'always',
             function(instance) {
-                this.masonry.layout();
+              this.masonry.layout();
             }.bind(this)
         );
     },


### PR DESCRIPTION
Adding updateOnEachImageLoad prop to be able to update component state and masonry layout on each image's load or broken status. 

This would update state for each image load which may hamper performance but will protect from broken layout in case of slow network connection where images are taking up lot of time to load and the view stays broken. Default case is set to false