### PR TITLE
Fix wrong default export in TypeScript typings

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -197,3 +197,4 @@ var MasonryComponent = React.createClass({
 });
 
 module.exports = MasonryComponent;
+module.exports.default = MasonryComponent;

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -28,5 +28,5 @@ declare module "react-masonry-component" {
     }
 
     const Masonry: ComponentClass<MasonryPropTypes>;
-    export = Masonry;
+    export default Masonry;
 }

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1,4 +1,4 @@
-import { Component } from "react";
+import { ComponentClass } from "react";
 
 declare module "react-masonry-component" {
 
@@ -27,5 +27,6 @@ declare module "react-masonry-component" {
         style?: Object;
     }
 
-    export default class Masonry extends Component<MasonryPropTypes, void> { }
+    const Masonry: ComponentClass<MasonryPropTypes>;
+    export = Masonry;
 }


### PR DESCRIPTION
Fixed TypeScript typings. 

Exporting as default actually creates an export named `default`. The JS code for the react-masonry-component doesn't do this, but sets `module.export =` the output from `React.createClass`, which is of type `ComponentClass<PropType>`.

When using the old typings as a default import in TypeScript:

```
import Masonry from "react-masonry-component";
```

You get this error on runtime:

```
warning.js:36 Warning: React.createElement: type should not be null, undefined, boolean, or number. It should be a string (for DOM elements) or a ReactClass (for composite components). Check the render method of `ExplorerView`.
invariant.js:38 Uncaught Invariant Violation: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: undefined. Check the render method of `ExplorerView`.
```

With the new typings, importing like this (which is the TypeScript equivalent of the export from the module):

```
import * as Masonry from "react-masonry-component";
```

Works with no error.