### PR TITLE
make resizable children trigger masonry layout

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,12 +2,14 @@ var isBrowser = typeof window !== 'undefined';
 var Masonry = isBrowser ? window.Masonry || require('masonry-layout') : null;
 var imagesloaded = isBrowser ? require('imagesloaded') : null;
 var assign = require('lodash.assign');
+var elementResizeDetectorMaker = require('element-resize-detector');
 var debounce = require('lodash.debounce');
 var omit = require('lodash.omit');
 var React = require('react');
 var refName = 'masonryContainer';
 
 var propTypes = {
+    enableResizableChildren: React.PropTypes.bool,
     disableImagesLoaded: React.PropTypes.bool,
     onImagesLoaded: React.PropTypes.func,
     updateOnEachImageLoad: React.PropTypes.bool,
@@ -18,6 +20,8 @@ var propTypes = {
 var MasonryComponent = React.createClass({
     masonry: false,
 
+	erd:undefined,
+
     domChildren: [],
 
     displayName: 'MasonryComponent',
@@ -26,6 +30,7 @@ var MasonryComponent = React.createClass({
 
     getDefaultProps: function() {
         return {
+            enableResizableChildren: false,
             disableImagesLoaded: false,
             updateOnEachImageLoad: false,
             options: {},
@@ -132,6 +137,9 @@ var MasonryComponent = React.createClass({
         var diff = this.diffDomChildren();
 
         if (diff.removed.length > 0) {
+			if (this.props.enableResizableChildren) {
+				diff.removed.forEach(this.erd.removeAllListeners, this.erd);
+			}
             this.masonry.remove(diff.removed);
             this.masonry.reloadItems();
         }
@@ -141,10 +149,16 @@ var MasonryComponent = React.createClass({
             if (diff.prepended.length === 0) {
                 this.masonry.reloadItems();
             }
+			if (this.props.enableResizableChildren) {
+				diff.appended.forEach(this.listenToElementResize, this);
+			}
         }
 
         if (diff.prepended.length > 0) {
             this.masonry.prepended(diff.prepended);
+			if (this.props.enableResizableChildren) {
+				diff.prepended.forEach(this.listenToElementResize, this);
+			}
         }
 
         if (diff.moved.length > 0) {
@@ -168,8 +182,27 @@ var MasonryComponent = React.createClass({
           );
     },
 
+    initializeResizableChildren: function() {
+        if (!this.props.enableResizableChildren) return;
+
+        this.erd = elementResizeDetectorMaker({
+          strategy: 'scroll'
+        });
+
+		this.domChildren.forEach(this.listenToElementResize, this);
+	},
+
+    listenToElementResize: function(el) {
+		this.erd.listenTo(el, function() {this.masonry.layout()}.bind(this))
+	},
+
+    destroyErd: function() {
+		this.domChildren.forEach(this.erd.uninstall, this.erd);
+	},
+
     componentDidMount: function() {
         this.initializeMasonry();
+		this.initializeResizableChildren();
         this.imagesLoaded();
     },
 
@@ -179,6 +212,7 @@ var MasonryComponent = React.createClass({
     },
 
     componentWillUnmount: function() {
+		this.destroyErd();
         this.masonry.destroy();
     },
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "A masonry component for React.js",
   "typings": "typings.d.ts",
   "dependencies": {
+    "element-resize-detector": "^1.1.9",
     "imagesloaded": "^4.0.0",
     "lodash.assign": "^4.0.9",
     "lodash.debounce": "^4.0.6",

--- a/spec/react-masonry-component-test.js
+++ b/spec/react-masonry-component-test.js
@@ -15,6 +15,7 @@ describe('React Masonry Component', function() {
         const component = TestUtils.renderIntoDocument(<MasonryComponent/>);
 
         expect(component.props).toEqual({
+            enableResizableChildren: false,
             disableImagesLoaded: false,
             updateOnEachImageLoad: false,
             options: {},
@@ -104,6 +105,7 @@ describe('React Masonry Component', function() {
         const component = TestUtils.renderIntoDocument(<MasonryComponent onClick={handler} test="testProp"/>);
 
         expect(component.props).toEqual({
+			enableResizableChildren: false,
             disableImagesLoaded: false,
             updateOnEachImageLoad: false,
             options: {},


### PR DESCRIPTION
I fixed issue #5 and modified tests to pass. It uses element-resize-detector from npm to detect size changes of child elements, so no need for the using component to track anything. I added a prop to opt-in for this behaviour, with set to false (default) ERD gets not setup.