### PR TITLE
Add support for events passed down as props

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ you can do so by using `refs`.
 ##### Events
 
 - `onImagesLoaded` - triggered when all images are loaded or after each image is loaded when `updateOnEachImageLoad` is set to `true`
+- `onLayoutComplete` - triggered after a layout and all positioning transitions have completed. 
+- `onRemoveComplete` - triggered after an item element has been removed
 
 ```jsx
 var Gallery = React.createClass({
@@ -152,6 +154,8 @@ var Gallery = React.createClass({
         return (
             <Masonry
                 onImagesLoaded={this.handleImagesLoaded}
+                onLayoutComplete={laidOutItems => this.handleLayoutComplete(laidOutItems)}
+                onRemoveComplete={removedItems => this.handleRemoveComplete(removedItems)}
             >
                 {...}
             </Masonry>

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,8 +38,8 @@ var MasonryComponent = React.createClass({
             options: {},
             className: '',
             elementType: 'div',
-            onLayoutComplete: () => {},
-            onRemoveComplete: () => {}
+            onLayoutComplete: function() {},
+            onRemoveComplete: function() {}
         };
     },
 
@@ -49,7 +49,7 @@ var MasonryComponent = React.createClass({
                 this.refs[refName],
                 this.props.options
             );
-            
+
             if (this.props.onLayoutComplete) {
                 this.masonry.on('layoutComplete', this.props.onLayoutComplete);
             }

--- a/lib/index.js
+++ b/lib/index.js
@@ -55,7 +55,7 @@ var MasonryComponent = React.createClass({
             }
 
             if (this.props.onRemoveComplete) {
-                this.masonry.on('layoutComplete', this.props.onRemoveComplete);
+                this.masonry.on('removeComplete', this.props.onRemoveComplete);
             }
 
             this.domChildren = this.getNewDomChildren();
@@ -230,6 +230,16 @@ var MasonryComponent = React.createClass({
 
     componentWillUnmount: function() {
         this.destroyErd();
+
+        // unregister events
+        if (this.props.onLayoutComplete) {
+            this.masonry.off('layoutComplete', this.props.onLayoutComplete);
+        }
+
+        if (this.props.onRemoveComplete) {
+            this.masonry.off('removeComplete', this.props.onLayoutComplete);
+        }
+
         this.masonry.destroy();
     },
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,9 @@ var propTypes = {
     onImagesLoaded: React.PropTypes.func,
     updateOnEachImageLoad: React.PropTypes.bool,
     options: React.PropTypes.object,
-    elementType: React.PropTypes.string
+    elementType: React.PropTypes.string,
+    onLayoutComplete: React.PropTypes.func,
+    onRemoveComplete: React.PropTypes.func
 };
 
 var MasonryComponent = React.createClass({
@@ -35,7 +37,9 @@ var MasonryComponent = React.createClass({
             updateOnEachImageLoad: false,
             options: {},
             className: '',
-            elementType: 'div'
+            elementType: 'div',
+            onLayoutComplete: () => {},
+            onRemoveComplete: () => {}
         };
     },
 
@@ -45,6 +49,14 @@ var MasonryComponent = React.createClass({
                 this.refs[refName],
                 this.props.options
             );
+            
+            if (this.props.onLayoutComplete) {
+                this.masonry.on('layoutComplete', this.props.onLayoutComplete);
+            }
+
+            if (this.props.onRemoveComplete) {
+                this.masonry.on('layoutComplete', this.props.onRemoveComplete);
+            }
 
             this.domChildren = this.getNewDomChildren();
         }

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "karma-webpack": "^1.7.0",
     "mocha": "^2.3.4",
     "phantomjs": "^1.9.19",
-    "react": "^15.0.1",
-    "react-dom": "^15.0.1",
+    "react": "~15.0.1",
+    "react-dom": "~15.0.1",
     "webpack": "^1.12.9"
   },
   "peerDependencies": {

--- a/spec/react-masonry-component-test.js
+++ b/spec/react-masonry-component-test.js
@@ -21,8 +21,8 @@ describe('React Masonry Component', function() {
             options: {},
             className: '',
             elementType: 'div',
-            onLayoutComplete: () => {},
-            onRemoveComplete: () => {}
+            onLayoutComplete: function() {},
+            onRemoveComplete: function() {}
         });
     });
 
@@ -103,7 +103,7 @@ describe('React Masonry Component', function() {
     });
 
     it('should allow custom props', function() {
-        const handler = () => {};
+        const handler = function() {};
         const component = TestUtils.renderIntoDocument(<MasonryComponent onClick={handler}/>);
 
         expect(component.props).toEqual({
@@ -114,8 +114,8 @@ describe('React Masonry Component', function() {
             className: '',
             elementType: 'div',
             onClick: handler,
-            onLayoutComplete: () => {},
-            onRemoveComplete: () => {}
+            onLayoutComplete: function() {},
+            onRemoveComplete: function() {}
         });
     });
 
@@ -136,10 +136,10 @@ describe('React Masonry Component', function() {
             layoutComplete: false,
             removeComplete: false
         };
-        const layoutEventHandler = () => {
+        const layoutEventHandler = function() {
             passed.layoutComplete = true;
         };
-        const removeEventHandler = () => {
+        const removeEventHandler = function() {
             passed.removeComplete = true;
         };
 
@@ -158,12 +158,14 @@ describe('React Masonry Component', function() {
 
         const component = TestUtils.renderIntoDocument(<Wrapper />);
 
-        setTimeout(() => {
+        this.timeout(3000);
+
+        setTimeout(function() {
             expect(passed).toEqual({
                 layoutComplete: true,
                 removeComplete: true
             });
             done();
-        }, 1500);
+        }, 2000);
     });
 });

--- a/spec/react-masonry-component-test.js
+++ b/spec/react-masonry-component-test.js
@@ -20,7 +20,9 @@ describe('React Masonry Component', function() {
             updateOnEachImageLoad: false,
             options: {},
             className: '',
-            elementType: 'div'
+            elementType: 'div',
+            onLayoutComplete: () => {},
+            onRemoveComplete: () => {}
         });
     });
 
@@ -102,7 +104,7 @@ describe('React Masonry Component', function() {
 
     it('should allow custom props', function() {
         const handler = () => {};
-        const component = TestUtils.renderIntoDocument(<MasonryComponent onClick={handler} test="testProp"/>);
+        const component = TestUtils.renderIntoDocument(<MasonryComponent onClick={handler}/>);
 
         expect(component.props).toEqual({
 			enableResizableChildren: false,
@@ -112,7 +114,8 @@ describe('React Masonry Component', function() {
             className: '',
             elementType: 'div',
             onClick: handler,
-            test: 'testProp'
+            onLayoutComplete: () => {},
+            onRemoveComplete: () => {}
         });
     });
 
@@ -126,5 +129,41 @@ describe('React Masonry Component', function() {
         const component = TestUtils.renderIntoDocument(<Wrapper/>);
         const ml = require('masonry-layout');
         expect(component.masonry instanceof ml).toEqual(true);
+    });
+
+    it('should support events as props', function(done) {
+        let passed = {
+            layoutComplete: false,
+            removeComplete: false
+        };
+        const layoutEventHandler = () => {
+            passed.layoutComplete = true;
+        };
+        const removeEventHandler = () => {
+            passed.removeComplete = true;
+        };
+
+        let masonry;
+
+        let Wrapper = React.createClass({
+            render() {
+                return (
+                    <MasonryComponent
+                        onLayoutComplete={layoutEventHandler}
+                        onRemoveComplete={removeEventHandler}
+                        ref={c => masonry = c.masonry} />
+                );
+            }
+        });
+
+        const component = TestUtils.renderIntoDocument(<Wrapper />);
+
+        setTimeout(() => {
+            expect(passed).toEqual({
+                layoutComplete: true,
+                removeComplete: true
+            });
+            done();
+        }, 1500);
     });
 });

--- a/spec/react-masonry-component-test.js
+++ b/spec/react-masonry-component-test.js
@@ -145,18 +145,29 @@ describe('React Masonry Component', function() {
 
         let masonry;
 
+        let children = childrenElements.slice().map(function(child, index) {
+            return <li key={index}>{child}</li>
+        });
+
         let Wrapper = React.createClass({
             render() {
                 return (
                     <MasonryComponent
                         onLayoutComplete={layoutEventHandler}
                         onRemoveComplete={removeEventHandler}
-                        ref={c => masonry = c.masonry} />
+                        ref={c => masonry = c.masonry}>
+                        {children}
+                    </MasonryComponent>
                 );
             }
         });
 
-        const component = TestUtils.renderIntoDocument(<Wrapper />);
+        let div = document.createElement('div');
+        document.body.appendChild(div);
+
+        ReactDOM.render(<Wrapper/>, div);
+
+        masonry.remove(children[0]);
 
         this.timeout(3000);
 

--- a/spec/setup/karma.conf.js
+++ b/spec/setup/karma.conf.js
@@ -19,7 +19,7 @@ module.exports = function (config) {
                     {
                         test: /\.jsx?$/,
                         exclude: /node_modules/,
-                        loader: 'babel-loader'
+                        loader: 'babel'
                     },
                     {
                         test: /masonry|imagesloaded|fizzy\-ui\-utils|desandro\-|outlayer|get\-size|doc\-ready|eventie|eventemitter/,

--- a/spec/setup/karma.conf.js
+++ b/spec/setup/karma.conf.js
@@ -19,7 +19,7 @@ module.exports = function (config) {
                     {
                         test: /\.jsx?$/,
                         exclude: /node_modules/,
-                        loader: 'babel'
+                        loader: 'babel-loader'
                     },
                     {
                         test: /masonry|imagesloaded|fizzy\-ui\-utils|desandro\-|outlayer|get\-size|doc\-ready|eventie|eventemitter/,


### PR DESCRIPTION
This PR adds support for passing down events as props instead of having to create a reference.
At Tattoodo we've encountered this issue when using the Masonry in a stateless component.

Further more I removed the test-property, since it failed the test. Can put it back in, but React whined about it, since it wasn't defined in the propTypes