### PR TITLE
typings.d.ts using export as namespace syntax as recommended for exte…

### DIFF
--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1,32 +1,30 @@
 import { ComponentClass } from "react";
 
-declare module "react-masonry-component" {
-
-    export interface MasonryOptions {
-        columnWidth?: number;
-        itemSelector?: string;
-        gutter?: number;
-        percentPosition?: boolean;
-        stamp?: string;
-        fitWidth?: boolean;
-        originLeft?: boolean;
-        originTop?: boolean;
-        containerStyle?: Object;
-        transitionDuration?: string;
-        resize?: boolean;
-        initLayout?: boolean;
-    }
-
-    interface MasonryPropTypes {
-        disableImagesLoaded?: boolean;
-        updateOnEachImageLoad?: boolean;
-        onImagesLoaded?: (instance: any) => void;
-        options?: MasonryOptions;
-        className?: string;
-        elementType?: string;
-        style?: Object;
-    }
-
-    const Masonry: ComponentClass<MasonryPropTypes>;
-    export default Masonry;
+export interface MasonryOptions {
+    columnWidth?: number;
+    itemSelector?: string;
+    gutter?: number;
+    percentPosition?: boolean;
+    stamp?: string;
+    fitWidth?: boolean;
+    originLeft?: boolean;
+    originTop?: boolean;
+    containerStyle?: Object;
+    transitionDuration?: string;
+    resize?: boolean;
+    initLayout?: boolean;
 }
+
+export interface MasonryPropTypes {
+    disableImagesLoaded?: boolean;
+    updateOnEachImageLoad?: boolean;
+    onImagesLoaded?: (instance: any) => void;
+    options?: MasonryOptions;
+    className?: string;
+    elementType?: string;
+    style?: Object;
+}
+
+declare const Masonry: ComponentClass<MasonryPropTypes>;
+export as namespace Masonry;
+export default Masonry;


### PR DESCRIPTION
…rnal modules


https://www.typescriptlang.org/docs/handbook/modules.html

It is recommended for "external modules" e.g. npm installable modules to use this syntax for declaration files.

Also, the current typings file prevents any typescript project from using this repo:

`error TS2666: Exports and export assignments are not permitted in module augmentations.`

And modules that provide a "typings" field in package.json cannot blacklist an incorrect typings file.