### PR TITLE
Fix layouts when removing elements.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -65,13 +65,7 @@ var MasonryComponent = React.createClass({
     },
 
     diffDomChildren: function() {
-        var oldChildren = this.domChildren.filter(function(element) {
-            /*
-             * take only elements attached to DOM
-             * (aka the parent is the masonry container, not null)
-             */
-            return !!element.parentNode;
-        });
+        var oldChildren = this.domChildren;
 
         var newChildren = this.getNewDomChildren();
 


### PR DESCRIPTION
It seems that my elements have already been removed from the DOM by the time componentDidUpdate is called, and so checking parentNode isn't useful here.

Should fix https://github.com/eiriklv/react-masonry-component/issues/61