### PR TITLE
Handle first element removal bug

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22,7 +22,7 @@ var propTypes = {
 var MasonryComponent = React.createClass({
     masonry: false,
 	  erd: undefined,
-    domChildren: [],
+    latestKnownDomChildren: [],
     displayName: 'MasonryComponent',
     propTypes: propTypes,
 
@@ -54,34 +54,60 @@ var MasonryComponent = React.createClass({
                 this.masonry.on('removeComplete', this.props.onRemoveComplete);
             }
 
-            this.domChildren = this.getNewDomChildren();
+            this.latestKnownDomChildren = this.getCurrentDomChildren();
         }
     },
 
-    getNewDomChildren: function() {
+    getCurrentDomChildren: function() {
         var node = this.refs[refName];
         var children = this.props.options.itemSelector ? node.querySelectorAll(this.props.options.itemSelector) : node.children;
         return Array.prototype.slice.call(children);
     },
 
     diffDomChildren: function() {
-        var oldChildren = this.domChildren;
+        let forceItemReload = false;
 
-        var newChildren = this.getNewDomChildren();
-
-        var removed = oldChildren.filter(function(oldChild) {
-            return !~newChildren.indexOf(oldChild);
+        var knownChildrenStillAttached = this.latestKnownDomChildren.filter(function(element) {
+            /*
+             * take only elements attached to DOM
+             * (aka the parent is the masonry container, not null)
+             * otherwise masonry would try to "remove it" again from the DOM
+             */
+            return !!element.parentNode;
         });
 
-        var domDiff = newChildren.filter(function(newChild) {
-            return !~oldChildren.indexOf(newChild);
+        /*
+         * If not all known children are attached to the dom - we have no other way of notifying
+         * masonry to remove the ones not still attached besides invoking a complete item reload.
+         * basically all the rest of the code below does not matter in that case.
+         */
+        if (knownChildrenStillAttached.length !== this.latestKnownDomChildren) {
+            forceItemReload = true;
+        }
+
+        var currentDomChildren = this.getCurrentDomChildren();
+
+        /*
+         * Since we are looking for a known child which is also attached to the dom AND
+         * not attached to the dom at the same time - this would *always* produce an empty array.
+         */
+        var removed = knownChildrenStillAttached.filter(function(attachedKnownChild) {
+            return !~currentDomChildren.indexOf(attachedKnownChild);
+        });
+
+        /*
+         * This would get any children which are attached to the dom but are *unkown* to us
+         * from previous renders
+         */
+        var newDomChildren = currentDomChildren.filter(function(currentChild) {
+            return !~knownChildrenStillAttached.indexOf(currentChild);
         });
 
         var beginningIndex = 0;
 
         // get everything added to the beginning of the DOMNode list
-        var prepended = domDiff.filter(function(newChild, i) {
-            var prepend = (beginningIndex === newChildren.indexOf(newChild));
+        var prepended = newDomChildren.filter(function(newChild, i) {
+            var prepend = (beginningIndex === currentDomChildren.indexOf(newChild));
 
             if (prepend) {
                 // increase the index
@@ -92,7 +118,7 @@ var MasonryComponent = React.createClass({
         });
 
         // we assume that everything else is appended
-        var appended = domDiff.filter(function(el) {
+        var appended = newDomChildren.filter(function(el) {
             return prepended.indexOf(el) === -1;
         });
 
@@ -101,10 +127,10 @@ var MasonryComponent = React.createClass({
          * have been added at the end of the list. this complex logic is preserved in case it needs to be
          * invoked
          *
-         * var endingIndex = newChildren.length - 1;
+         * var endingIndex = currentDomChildren.length - 1;
          *
-         * domDiff.reverse().filter(function(newChild, i){
-         *     var append = endingIndex == newChildren.indexOf(newChild);
+         * newDomChildren.reverse().filter(function(newChild, i){
+         *     var append = endingIndex == currentDomChildren.indexOf(newChild);
          *
          *     if (append) {
          *         endingIndex--;
@@ -117,31 +143,42 @@ var MasonryComponent = React.createClass({
         // get everything added to the end of the DOMNode list
         var moved = [];
 
+        /*
+         * This would always be true (see above about the lofic for "removed")
+         */
         if (removed.length === 0) {
-            moved = oldChildren.filter(function(child, index) {
-                return index !== newChildren.indexOf(child);
+            /*
+             * 'moved' will contain some random elements (if any) since the "knownChildrenStillAttached" is a filter
+             * of the "known" children which are still attached - All indexes could basically change. (for example
+             * if the first element is not attached)
+             * Don't trust this array.
+             */
+            moved = knownChildrenStillAttached.filter(function(child, index) {
+                return index !== currentDomChildren.indexOf(child);
             });
         }
 
-        this.domChildren = newChildren;
+        this.latestKnownDomChildren = currentDomChildren;
 
         return {
-            old: oldChildren,
-            new: newChildren,
+            old: knownChildrenStillAttached, // Not used
+            new: currentDomChildren, // Not used
             removed: removed,
             appended: appended,
             prepended: prepended,
-            moved: moved
+            moved: moved,
+            forceItemReload
         };
     },
 
     performLayout: function() {
         var diff = this.diffDomChildren();
 
+        // Would never be true. (see comments of 'diffDomChildren' about 'removed')
         if (diff.removed.length > 0) {
-			      if (this.props.enableResizableChildren) {
-				        diff.removed.forEach(this.erd.removeAllListeners, this.erd);
-			      }
+            if (this.props.enableResizableChildren) {
+                diff.removed.forEach(this.erd.removeAllListeners, this.erd);
+            }
             this.masonry.remove(diff.removed);
             this.masonry.reloadItems();
         }
@@ -154,19 +191,19 @@ var MasonryComponent = React.createClass({
             }
 
             if (this.props.enableResizableChildren) {
-				        diff.appended.forEach(this.listenToElementResize, this);
-			      }
+                diff.appended.forEach(this.listenToElementResize, this);
+			}
         }
 
         if (diff.prepended.length > 0) {
             this.masonry.prepended(diff.prepended);
 
             if (this.props.enableResizableChildren) {
-				        diff.prepended.forEach(this.listenToElementResize, this);
-			      }
+                diff.prepended.forEach(this.listenToElementResize, this);
+            }
         }
 
-        if (diff.moved.length > 0) {
+        if (diff.forceItemReload || diff.moved.length > 0) {
             this.masonry.reloadItems();
         }
 
@@ -194,7 +231,7 @@ var MasonryComponent = React.createClass({
             strategy: 'scroll'
         });
 
-		    this.domChildren.forEach(this.listenToElementResize, this);
+		    this.latestKnownDomChildren.forEach(this.listenToElementResize, this);
 	  },
 
         listenToElementResize: function(el) {
@@ -203,7 +240,7 @@ var MasonryComponent = React.createClass({
 
     destroyErd: function() {
         if (this.erd) {
-            this.domChildren.forEach(this.erd.uninstall, this.erd);
+            this.latestKnownDomChildren.forEach(this.erd.uninstall, this.erd);
         }
     },
 

--- a/spec/react-masonry-component-test.js
+++ b/spec/react-masonry-component-test.js
@@ -198,6 +198,7 @@ describe('React Masonry Component', function() {
         expect(secondElements[i].style.top).toEqual(secondPositions[i].top + 'px');
       }
     });
+
     it('should correctly layout new elements when completely replacing child items [transitionDuration zero]', function() {
       let wrapperContext;
       class Wrapper extends React.Component {
@@ -242,6 +243,155 @@ describe('React Masonry Component', function() {
       for (let i = 0; i < secondElements.length; i++) {
         expect(secondElements[i].style.left).toEqual(secondPositions[i].left + 'px');
         expect(secondElements[i].style.top).toEqual(secondPositions[i].top + 'px');
+      }
+    });
+  });
+
+  describe('removing elements', function() {
+    const localChildrenElements = [
+      { k: 0, cn: 'h4' },
+      { k: 1, cn: 'h3' },
+      { k: 2, cn: 'h3' },
+      { k: 3, cn: 'w2' },
+      { k: 4, cn: 'h2' }];
+
+    const firstPositions = {
+      0: {
+        left: 0,
+        top: 0
+      },
+      1: {
+        left: 60,
+        top: 0
+      },
+      2: {
+        left: 120,
+        top: 0
+      },
+      3: {
+        left: 60,
+        top: 70
+      },
+      4: {
+        left: 0,
+        top: 90
+      }
+    };
+
+    const secondPositions = {
+      0: {
+        left: 0,
+        top: 0
+      },
+      1: {
+        left: 60,
+        top: 0
+      },
+      2: {
+        left: 0,
+        top: 70
+      },
+      3: {
+        left: 120,
+        top: 0
+      }
+    };
+
+    const failureMessage = (index, property, expectedValue, actualValue, phase) =>
+      `property "${property}" expected to be ${expectedValue} but is ${actualValue} on phase "${phase}" - index ${index}`;
+
+    const expectElementPositionToMatch = (element, expectedPosition, index, phase) => {
+      expect(element.style.left).toEqual(expectedPosition.left + 'px',
+          failureMessage(index, 'left', expectedPosition.left + 'px', element.style.left, phase))
+      expect(element.style.top).toEqual(expectedPosition.top + 'px',
+          failureMessage(index, 'top', expectedPosition.top + 'px', element.style.top, phase))
+    }
+
+    it('should correctly layout remaining elements when first element is removed [columnWidth empty]', function() {
+      let wrapperContext;
+      class Wrapper extends React.Component {
+        constructor() {
+          super();
+          this.state = {
+            items: localChildrenElements.slice()
+          };
+
+          wrapperContext = this;
+        }
+
+        render() {
+          return (
+            <MasonryComponent className="container" elementType="ul" options={{transitionDuration: 0}}>
+              {
+                this.state.items.map(function(item, i) {
+                  return <li key={item.k} className={`item ${item.cn}`}></li>
+                })
+              }
+            </MasonryComponent>
+          );
+        }
+      }
+
+      let div = document.createElement('div');
+      document.body.appendChild(div);
+
+      ReactDOM.render(<Wrapper />, div);
+
+      const firstElements = div.querySelectorAll('.item');
+
+      for (let i = 0; i < firstElements.length; i++) {
+        expectElementPositionToMatch(firstElements[i], firstPositions[i], i, 'before removal');
+      }
+
+      wrapperContext.setState({items: localChildrenElements.slice(1)});
+      const secondElements = div.querySelectorAll('.item');
+
+      for (let i = 0; i < secondElements.length; i++) {
+        expectElementPositionToMatch(secondElements[i], secondPositions[i], i, 'after removal');
+      }
+    });
+
+    it('should correctly layout remaining elements when first element is removed [columnWidth fixed]', function() {
+      let wrapperContext;
+      class Wrapper extends React.Component {
+        constructor() {
+          super();
+          this.state = {
+            items: localChildrenElements.slice()
+          };
+
+          wrapperContext = this;
+        }
+
+        render() {
+          return (
+            <MasonryComponent className="container" elementType="ul" options={{transitionDuration: 0, columnWidth: 60}}>
+              {
+                this.state.items.map(function(item, i) {
+                  return <li key={item.k} className={`item ${item.cn}`}></li>
+                })
+              }
+            </MasonryComponent>
+          );
+        }
+      }
+
+      let div = document.createElement('div');
+      document.body.appendChild(div);
+
+      ReactDOM.render(<Wrapper />, div);
+
+      const firstElements = div.querySelectorAll('.item');
+
+      for (let i = 0; i < firstElements.length; i++) {
+        expectElementPositionToMatch(firstElements[i], firstPositions[i], i, 'before removal');
+      }
+
+      wrapperContext.setState({items: localChildrenElements.slice(1)});
+      const secondElements = div.querySelectorAll('.item');
+
+      for (let i = 0; i < secondElements.length; i++) {
+        expectElementPositionToMatch(secondElements[i], secondPositions[i], i, 'after removal');
       }
     });
   });


### PR DESCRIPTION
Added tests only pinpoint the problem but many more could be added to cover the different use cases.
Logic of diffing is screwed up atm - commented to light up the problematic parts but aside from fixing what is need to overcome this bug did not refactor the entire thing (which should be done when more tests are in place).

This also reverts the diffing algorithm calculation to it's behavior pre v5.0.0