### PR TITLE
Allow selector-based columnWidth

### DIFF
--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1,7 +1,7 @@
 import { ComponentClass } from "react";
 
 export interface MasonryOptions {
-    columnWidth?: number;
+    columnWidth?: number | string;
     itemSelector?: string;
     gutter?: number;
     percentPosition?: boolean;


### PR DESCRIPTION
Masonry allows for the columnWidth property to be a string in which case it will use that as a CSS selector to calculate the column width. This updated the typescript interface to reflect that.