### PR TITLE
Replacing string ref with method

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -281,10 +281,14 @@ var MasonryComponent = createReactClass({
 
     this.masonry.destroy();
   },
+  
+  setRef: function(n) {
+    this.masonryContainer = n;
+  },
 
   render: function() {
     var props = omit(this.props, Object.keys(propTypes));
-    return React.createElement(this.props.elementType, assign({}, props, {ref: (n) => this.masonryContainer = n}), this.props.children);
+    return React.createElement(this.props.elementType, assign({}, props, {ref: this.setRef}), this.props.children);
   }
 });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -46,7 +46,7 @@ var MasonryComponent = createReactClass({
   initializeMasonry: function(force) {
     if (!this.masonry || force) {
       this.masonry = new Masonry(
-        this.refs[refName],
+        this.masonryContainer,
         this.props.options
       );
 
@@ -63,7 +63,7 @@ var MasonryComponent = createReactClass({
   },
 
   getCurrentDomChildren: function() {
-    var node = this.refs[refName];
+    var node = this.masonryContainer;
     var children = this.props.options.itemSelector ? node.querySelectorAll(this.props.options.itemSelector) : node.children;
     return Array.prototype.slice.call(children);
   },
@@ -219,7 +219,7 @@ var MasonryComponent = createReactClass({
       return;
     }
 
-    imagesloaded(this.refs[refName])
+    imagesloaded(this.masonryContainer)
       .on(
         this.props.updateOnEachImageLoad ? 'progress' : 'always',
         debounce(
@@ -284,7 +284,7 @@ var MasonryComponent = createReactClass({
 
   render: function() {
     var props = omit(this.props, Object.keys(propTypes));
-    return React.createElement(this.props.elementType, assign({}, props, {ref: refName}), this.props.children);
+    return React.createElement(this.props.elementType, assign({}, props, {ref: (n) => this.masonryContainer = n}), this.props.children);
   }
 });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,6 @@ var omit = require('lodash/omit');
 var PropTypes = require('prop-types');
 var React = require('react');
 var createReactClass = require('create-react-class');
-var refName = 'masonryContainer';
 
 var propTypes = {
   enableResizableChildren: PropTypes.bool,


### PR DESCRIPTION
Replaced legacy string ref with method to set the node to ```this.masonryContainer```. Fixes error when used with React 16:

```Element ref was specified as a string (masonryContainer) but no owner was set.```