### PR TITLE
Allow selector-based gutter

### DIFF
--- a/typings.d.ts
+++ b/typings.d.ts
@@ -3,7 +3,7 @@ import { ComponentClass } from "react";
 export interface MasonryOptions {
     columnWidth?: number | string;
     itemSelector?: string;
-    gutter?: number;
+    gutter?: number | string;
     percentPosition?: boolean;
     horizontalOrder?: boolean;
     stamp?: string;


### PR DESCRIPTION
Masonry allows for the gutter property to be a string in which case it will use that as a CSS selector to calculate the gutter. This updated the typescript interface to reflect that.