### PR TITLE
Use just utilities instead of lodash

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,10 +1,10 @@
 var isBrowser = typeof window !== 'undefined';
 var Masonry = isBrowser ? window.Masonry || require('masonry-layout') : null;
 var imagesloaded = isBrowser ? require('imagesloaded') : null;
-var assign = require('lodash/assign');
+var assign = require('just-merge');
 var elementResizeDetectorMaker = require('element-resize-detector');
-var debounce = require('lodash/debounce');
-var omit = require('lodash/omit');
+var debounce = require('just-debounce-it');
+var omit = require('just-omit');
 var PropTypes = require('prop-types');
 var React = require('react');
 var createReactClass = require('create-react-class');

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "create-react-class": "^15.6.2",
     "element-resize-detector": "^1.1.9",
     "imagesloaded": "^4.0.0",
-    "lodash": "^4.17.4",
+    "just-debounce-it": "^1.0.1",
+    "just-merge": "^1.0.2",
+    "just-omit": "^1.0.1",
     "masonry-layout": "^4.2.0",
     "prop-types": "^15.5.8"
   },


### PR DESCRIPTION
This change reduces the Javascript footprint of react-masonry-component
by switching to https://github.com/angus-c/just