### PR TITLE
Debounce layouts: fixes animation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,8 @@ var propTypes = {
   options: PropTypes.object,
   elementType: PropTypes.string,
   onLayoutComplete: PropTypes.func,
-  onRemoveComplete: PropTypes.func
+  onRemoveComplete: PropTypes.func,
+  updateOnEachComponentUpdate: PropTypes.bool
 };
 
 var MasonryComponent = createReactClass({
@@ -38,7 +39,8 @@ var MasonryComponent = createReactClass({
       onLayoutComplete: function() {
       },
       onRemoveComplete: function() {
-      }
+      },
+      updateOnEachComponentUpdate: true
     };
   },
 
@@ -211,8 +213,10 @@ var MasonryComponent = createReactClass({
       this.masonry.reloadItems();
     }
 
-    this.masonry.layout();
-  },
+		if (this.props.updateOnEachComponentUpdate) {
+			this.reloadLayout();
+		}
+	},
 
   imagesLoaded: function() {
     if (this.props.disableImagesLoaded) {
@@ -227,10 +231,16 @@ var MasonryComponent = createReactClass({
             if (this.props.onImagesLoaded) {
               this.props.onImagesLoaded(instance);
             }
-            this.masonry.layout();
+            this.reloadLayout();
           }.bind(this), 100)
       );
   },
+
+  reloadLayout: debounce(
+    function() {
+      this.masonry.layout();
+    }, 100
+  ),
 
   initializeResizableChildren: function() {
     if (!this.props.enableResizableChildren) {
@@ -245,9 +255,7 @@ var MasonryComponent = createReactClass({
   },
 
   listenToElementResize: function(el) {
-    this.erd.listenTo(el, function() {
-      this.masonry.layout()
-    }.bind(this))
+    this.erd.listenTo(el, this.reloadLayout);
   },
 
   destroyErd: function() {
@@ -281,7 +289,7 @@ var MasonryComponent = createReactClass({
 
     this.masonry.destroy();
   },
-  
+
   setRef: function(n) {
     this.masonryContainer = n;
   },

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -17,16 +17,17 @@ export interface MasonryOptions {
 }
 
 export interface MasonryPropTypes {
-    enableResizableChildren?: boolean;
-    disableImagesLoaded?: boolean;
-    updateOnEachImageLoad?: boolean;
-    onImagesLoaded?: (instance: any) => void;
-    options?: MasonryOptions;
-    className?: string;
-    elementType?: string;
-    style?: Object;
-    onLayoutComplete?: (instance: any) => void;
-    onRemoveComplete?: (instance: any) => void;
+	enableResizableChildren?: boolean;
+	disableImagesLoaded?: boolean;
+	updateOnEachImageLoad?: boolean;
+	onImagesLoaded?: (instance: any) => void;
+	options?: MasonryOptions;
+	className?: string;
+	elementType?: string;
+	style?: Object;
+	onLayoutComplete?: (instance: any) => void;
+	onRemoveComplete?: (instance: any) => void;
+	updateOnEachComponentUpdate?: boolean;
 }
 
 declare const Masonry: ComponentClass<MasonryPropTypes>;

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -17,17 +17,17 @@ export interface MasonryOptions {
 }
 
 export interface MasonryPropTypes {
-	enableResizableChildren?: boolean;
-	disableImagesLoaded?: boolean;
-	updateOnEachImageLoad?: boolean;
-	onImagesLoaded?: (instance: any) => void;
-	options?: MasonryOptions;
-	className?: string;
-	elementType?: string;
-	style?: Object;
-	onLayoutComplete?: (instance: any) => void;
-	onRemoveComplete?: (instance: any) => void;
-	updateOnEachComponentUpdate?: boolean;
+    enableResizableChildren?: boolean;
+    disableImagesLoaded?: boolean;
+    updateOnEachImageLoad?: boolean;
+    onImagesLoaded?: (instance: any) => void;
+    options?: MasonryOptions;
+    className?: string;
+    elementType?: string;
+    style?: Object;
+    onLayoutComplete?: (instance: any) => void;
+    onRemoveComplete?: (instance: any) => void;
+    updateOnEachComponentUpdate?: boolean;
 }
 
 declare const Masonry: ComponentClass<MasonryPropTypes>;


### PR DESCRIPTION
This is a fix for #109.

Calls to `masonry.layout()` are now debounced.

There's also a new (default true) prop to turn on calls to `layout()` on `componentUpdate`.