### PR TITLE
Unbind imagesLoaded event

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,6 +25,7 @@ var MasonryComponent = createReactClass({
   erd: undefined,
   latestKnownDomChildren: [],
   displayName: 'MasonryComponent',
+  imagesLoadedCancellers: [],
   propTypes: propTypes,
 
   getDefaultProps: function() {
@@ -219,17 +220,23 @@ var MasonryComponent = createReactClass({
       return;
     }
 
-    imagesloaded(this.masonryContainer)
-      .on(
-        this.props.updateOnEachImageLoad ? 'progress' : 'always',
-        debounce(
-          function(instance) {
-            if (this.props.onImagesLoaded) {
-              this.props.onImagesLoaded(instance);
-            }
-            this.masonry.layout();
-          }.bind(this), 100)
-      );
+    var event = this.props.updateOnEachImageLoad ? 'progress' : 'always';
+    var handler = debounce(
+      function(instance) {
+        if (this.props.onImagesLoaded) {
+          this.props.onImagesLoaded(instance);
+        }
+        this.masonry.layout();
+      }.bind(this), 100);
+
+    var imgLoad = imagesloaded(this.masonryContainer).on(event, handler);
+
+    var canceller = function() {
+      handler.cancel();
+      imgLoad.off(event, handler);
+    };
+
+    this.imagesLoadedCancellers.push(canceller);
   },
 
   initializeResizableChildren: function() {
@@ -257,6 +264,7 @@ var MasonryComponent = createReactClass({
   },
 
   componentDidMount: function() {
+    this.imagesLoadedCancellers = [];
     this.initializeMasonry();
     this.initializeResizableChildren();
     this.imagesLoaded();
@@ -278,6 +286,10 @@ var MasonryComponent = createReactClass({
     if (this.props.onRemoveComplete) {
       this.masonry.off('removeComplete', this.props.onRemoveComplete);
     }
+
+    this.imagesLoadedCancellers.forEach(function(canceller) {
+      canceller();
+    });
 
     this.masonry.destroy();
   },


### PR DESCRIPTION
When masonry component is unmounted before finishing all imagesloaded callback, the callback still triggers the bound function. In my case, since I called `setState` in the function, I got a following warning.

```
Warning: Can only update a mounted or mounting component. This usually means you called setState, replaceState, or forceUpdate on an unmounted component. This is a no-op.
```

In order to fix this issue, I added unbinding code to `componentWillUnmount`.