### PR TITLE
🐛 this.imagesLoadedCancelRef is not a function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -295,7 +295,9 @@ var MasonryComponent = createReactClass({
       this.masonry.off('removeComplete', this.props.onRemoveComplete);
     }
 
-    this.derefImagesLoaded();
+    if (this.imagesLoadedCancelRef) {
+      this.derefImagesLoaded();
+    }
     this.masonry.destroy();
   },
   


### PR DESCRIPTION
## Description
When `disableImagesLoaded` is true, `componentWillUnmount` throws `this.imagesLoadedCancelRef is not a function`

### How to reproduce
- Pass `disableImagesLoaded` prop, render then unmount the component.

### Fix
- Only call `derefImagesLoaded` in `componentWillUnmount` if `imagesLoadedCancelRef` was truthy.

<img width="556" alt="screen shot 2018-05-29 at 6 58 51 am" src="https://user-images.githubusercontent.com/12428415/40638815-cc2cba92-630d-11e8-9407-552783509e82.png">
