### PR TITLE
rm redundant ES Modules documentation, now included

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,6 @@ class Gallery extends React.Component {
 export default Gallery;
 ```
 
-ES6-style modules are also supported, just use:
-
-```js
-import Masonry from 'react-masonry-component';
-```
-
 ##### Custom props
 You can also include your own custom props - EG: inline-style and event handlers.
 


### PR DESCRIPTION
The removed section should have been removed along with [this commit](https://github.com/eiriklv/react-masonry-component/commit/e114a464058d8cc7d67526a7f74e549d98cf043c#diff-04c6e90faac2675aa89e2176d2eec7d8L38).