### PR TITLE
Replace deprecated getDefaultProps with static defaultProps

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,22 +29,6 @@ var MasonryComponent = createReactClass({
   imagesLoadedCancelRef: undefined,
   propTypes: propTypes,
 
-  getDefaultProps: function() {
-    return {
-      enableResizableChildren: false,
-      disableImagesLoaded: false,
-      updateOnEachImageLoad: false,
-      options: {},
-      imagesLoadedOptions: {},
-      className: '',
-      elementType: 'div',
-      onLayoutComplete: function() {
-      },
-      onRemoveComplete: function() {
-      }
-    };
-  },
-
   initializeMasonry: function(force) {
     if (!this.masonry || force) {
       this.masonry = new Masonry(
@@ -300,7 +284,7 @@ var MasonryComponent = createReactClass({
     }
     this.masonry.destroy();
   },
-  
+
   setRef: function(n) {
     this.masonryContainer = n;
   },
@@ -310,6 +294,20 @@ var MasonryComponent = createReactClass({
     return React.createElement(this.props.elementType, assign({}, props, {ref: this.setRef}), this.props.children);
   }
 });
+
+MasonryComponent.defaultProps = {
+    enableResizableChildren: false,
+    disableImagesLoaded: false,
+    updateOnEachImageLoad: false,
+    options: {},
+    imagesLoadedOptions: {},
+    className: '',
+    elementType: 'div',
+    onLayoutComplete: function() {
+    },
+    onRemoveComplete: function() {
+    }
+};
 
 module.exports = MasonryComponent;
 module.exports.default = MasonryComponent;


### PR DESCRIPTION
Patch change:  Just updating `getDefaultProps` to `defaultProps` to suppress a console warning.