### PR TITLE
Adding missing type of imagesLoadedOptions 

### DIFF
--- a/typings.d.ts
+++ b/typings.d.ts
@@ -21,7 +21,7 @@ export interface MasonryPropTypes {
     disableImagesLoaded?: boolean;
     updateOnEachImageLoad?: boolean;
     onImagesLoaded?: (instance: any) => void;
-    options?: MasonryOptions; //done
+    options?: MasonryOptions;
     className?: string;
     elementType?: string;
     imagesLoadedOptions?: Object;

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -21,9 +21,10 @@ export interface MasonryPropTypes {
     disableImagesLoaded?: boolean;
     updateOnEachImageLoad?: boolean;
     onImagesLoaded?: (instance: any) => void;
-    options?: MasonryOptions;
+    options?: MasonryOptions; //done
     className?: string;
     elementType?: string;
+    imagesLoadedOptions?: Object;
     style?: Object;
     onLayoutComplete?: (instance: any) => void;
     onRemoveComplete?: (instance: any) => void;


### PR DESCRIPTION
Adding missing type of imagesLoadedOptions in typings ... this blocks in using ```imagesLoadedOptions``` as prop when using component in typescript 