### PR TITLE
Add typing for children props

### DIFF
--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1,4 +1,4 @@
-import { ComponentClass } from "react";
+import React, { ComponentClass } from "react";
 
 export interface MasonryOptions {
     columnWidth?: number | string | HTMLElement | null;
@@ -27,6 +27,7 @@ export interface MasonryPropTypes {
     style?: Object;
     onLayoutComplete?: (instance: any) => void;
     onRemoveComplete?: (instance: any) => void;
+    children?: React.ReactNode | React.ReactNode[];
 }
 
 declare const Masonry: ComponentClass<MasonryPropTypes>;


### PR DESCRIPTION
Component usage
```js
const Work = () => {
  const childElements = workData.map((elem, index) => {
    return (
      <div className="masonry__brick" data-aos="fade-up" key={index}>
        <div className="item-folio">
          <div className="item-folio__thumb">
              <a href={elem.url} className="thumb-link" title={elem.title}>
                <DynamicImage
                  // fileName={elem.image}
                  fileName="portfolio/lady-shutterbug.jpg"
                  alt={elem.title}
                />
              </a>
          </div>
          <div className="item-folio__text">
            <h3 className="item-folio__title">
              {elem.title}
            </h3>
            <p className="item-folio__cat">
              {elem.category}
            </p>
          </div>
          <a href={elem.url} className="item-folio__project-link" title="Project link">
              <i className="icon-link"></i>
          </a>
          <div className="item-folio__caption">
            <p>{elem.description}</p>
          </div>
        </div>
      </div>
    );
  });
  
  return (
    <section id="works" className="s-works target-section">
      <div className="row section-header has-bottom-sep narrow target-section" data-aos="fade-up">
        <div className="col-full">
          <h3 className="subhead">Portfolio</h3>
          <h1 className="display-1">
            Check out my recent works.
          </h1>
        </div>
      </div>
      <div className="row masonry-wrap">
        <Masonry
          className={'masonry'} // default ''
          // elementType={'ul'} // default 'div'
          // options={masonryOptions} // default {}
          // disableImagesLoaded={false} // default false
          // updateOnEachImageLoad={false} // default false and works only if disableImagesLoaded is false
          // imagesLoadedOptions={imagesLoadedOptions} // default {}
        >
          {childElements}
        </Masonry>
      </div>
    </section>
  );
};

export default Work;
```

I encountered the following typescript error
```
Type '{ children: Element[]; className: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<MasonryPropTypes, any, any>> & Readonly<...>'.
  Property 'children' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<MasonryPropTypes, any, any>> & Readonly<...>'.ts(2322)
```

`children` is indeed not typed in https://github.com/eiriklv/react-masonry-component/blob/master/typings.d.ts#L19 so I created this pull request.